### PR TITLE
minim-openwifi-scripts: Default to DROP for wan input

### DIFF
--- a/minim-openwifi-scripts/files/etc/uci-defaults/34_drop_wan_input
+++ b/minim-openwifi-scripts/files/etc/uci-defaults/34_drop_wan_input
@@ -1,3 +1,3 @@
 # by default, reject incoming connections to wan
-uci set firewall.@zone[1].input=REJECT
+uci set firewall.@zone[1].input=DROP
 uci commit firewall


### PR DESCRIPTION
This is what cdrouter testing prefers

SW-1257 SW-683