### PR TITLE
Q14 leds

### DIFF
--- a/kmod-uleds/Makefile
+++ b/kmod-uleds/Makefile
@@ -1,0 +1,28 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=uleds
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Brett Mastbergen <brettm@minim.com>
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel-defaults.mk
+
+define KernelPackage/uleds
+  SUBMENU:=LED modules
+  TITLE:= Backported uleds driver
+  DEPENDS:=
+  FILES:=$(PKG_BUILD_DIR)/uleds.ko
+  AUTOLOAD:=$(call AutoLoad,30,uleds)
+  KCONFIG:=
+endef
+
+define KernelPackage/uleds/description
+  This is the uleds led class driver backported from 4.10
+endef
+
+define Build/Compile
+	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)" modules
+endef
+
+$(eval $(call KernelPackage,uleds))

--- a/kmod-uleds/src/Makefile
+++ b/kmod-uleds/src/Makefile
@@ -1,0 +1,9 @@
+obj-m += uleds.o
+
+all:
+	make -C $(KSRC) M=$(shell pwd) modules
+
+clean:
+	make -C $(KSRC) M=$(shell pwd) clean
+	@rm -rf Module.markers Module.symvers modules.order
+

--- a/kmod-uleds/src/uleds.c
+++ b/kmod-uleds/src/uleds.c
@@ -1,0 +1,235 @@
+/*
+ * Userspace driver for the LED subsystem
+ *
+ * Copyright (C) 2016 David Lechner <david@lechnology.com>
+ *
+ * Based on uinput.c: Aristeu Sergio Rozanski Filho <aris@cathedrallabs.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#include <linux/fs.h>
+#include <linux/init.h>
+#include <linux/leds.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/poll.h>
+#include <linux/sched.h>
+#include <linux/slab.h>
+
+#include "uleds.h"
+
+#define ULEDS_NAME	"uleds"
+
+enum uleds_state {
+	ULEDS_STATE_UNKNOWN,
+	ULEDS_STATE_REGISTERED,
+};
+
+struct uleds_device {
+	struct uleds_user_dev	user_dev;
+	struct led_classdev	led_cdev;
+	struct mutex		mutex;
+	enum uleds_state	state;
+	wait_queue_head_t	waitq;
+	int			brightness;
+	bool			new_data;
+};
+
+static struct miscdevice uleds_misc;
+
+static void uleds_brightness_set(struct led_classdev *led_cdev,
+				 enum led_brightness brightness)
+{
+	struct uleds_device *udev = container_of(led_cdev, struct uleds_device,
+						 led_cdev);
+
+	if (udev->brightness != brightness) {
+		udev->brightness = brightness;
+		udev->new_data = true;
+		wake_up_interruptible(&udev->waitq);
+	}
+}
+
+static int uleds_open(struct inode *inode, struct file *file)
+{
+	struct uleds_device *udev;
+
+	udev = kzalloc(sizeof(*udev), GFP_KERNEL);
+	if (!udev)
+		return -ENOMEM;
+
+	udev->led_cdev.name = udev->user_dev.name;
+	udev->led_cdev.brightness_set = uleds_brightness_set;
+
+	mutex_init(&udev->mutex);
+	init_waitqueue_head(&udev->waitq);
+	udev->state = ULEDS_STATE_UNKNOWN;
+
+	file->private_data = udev;
+	nonseekable_open(inode, file);
+
+	return 0;
+}
+
+static ssize_t uleds_write(struct file *file, const char __user *buffer,
+			   size_t count, loff_t *ppos)
+{
+	struct uleds_device *udev = file->private_data;
+	const char *name;
+	int ret;
+
+	if (count == 0)
+		return 0;
+
+	ret = mutex_lock_interruptible(&udev->mutex);
+	if (ret)
+		return ret;
+
+	if (udev->state == ULEDS_STATE_REGISTERED) {
+		ret = -EBUSY;
+		goto out;
+	}
+
+	if (count != sizeof(struct uleds_user_dev)) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (copy_from_user(&udev->user_dev, buffer,
+			   sizeof(struct uleds_user_dev))) {
+		ret = -EFAULT;
+		goto out;
+	}
+
+	name = udev->user_dev.name;
+	if (!name[0] || !strcmp(name, ".") || !strcmp(name, "..") ||
+	    strchr(name, '/')) {
+		ret = -EINVAL;
+		goto out;
+	}
+
+	if (udev->user_dev.max_brightness <= 0) {
+		ret = -EINVAL;
+		goto out;
+	}
+	udev->led_cdev.max_brightness = udev->user_dev.max_brightness;
+
+	ret = devm_led_classdev_register(uleds_misc.this_device,
+					 &udev->led_cdev);
+	if (ret < 0)
+		goto out;
+
+	udev->new_data = true;
+	udev->state = ULEDS_STATE_REGISTERED;
+	ret = count;
+
+out:
+	mutex_unlock(&udev->mutex);
+
+	return ret;
+}
+
+static ssize_t uleds_read(struct file *file, char __user *buffer, size_t count,
+			  loff_t *ppos)
+{
+	struct uleds_device *udev = file->private_data;
+	ssize_t retval;
+
+	if (count < sizeof(udev->brightness))
+		return 0;
+
+	do {
+		retval = mutex_lock_interruptible(&udev->mutex);
+		if (retval)
+			return retval;
+
+		if (udev->state != ULEDS_STATE_REGISTERED) {
+			retval = -ENODEV;
+		} else if (!udev->new_data && (file->f_flags & O_NONBLOCK)) {
+			retval = -EAGAIN;
+		} else if (udev->new_data) {
+			retval = copy_to_user(buffer, &udev->brightness,
+					      sizeof(udev->brightness));
+			udev->new_data = false;
+			retval = sizeof(udev->brightness);
+		}
+
+		mutex_unlock(&udev->mutex);
+
+		if (retval)
+			break;
+
+		if (!(file->f_flags & O_NONBLOCK))
+			retval = wait_event_interruptible(udev->waitq,
+					udev->new_data ||
+					udev->state != ULEDS_STATE_REGISTERED);
+	} while (retval == 0);
+
+	return retval;
+}
+
+static unsigned int uleds_poll(struct file *file, poll_table *wait)
+{
+	struct uleds_device *udev = file->private_data;
+
+	poll_wait(file, &udev->waitq, wait);
+
+	if (udev->new_data)
+		return POLLIN | POLLRDNORM;
+
+	return 0;
+}
+
+static int uleds_release(struct inode *inode, struct file *file)
+{
+	struct uleds_device *udev = file->private_data;
+
+	if (udev->state == ULEDS_STATE_REGISTERED) {
+		udev->state = ULEDS_STATE_UNKNOWN;
+		devm_led_classdev_unregister(uleds_misc.this_device,
+					     &udev->led_cdev);
+	}
+	kfree(udev);
+
+	return 0;
+}
+
+static const struct file_operations uleds_fops = {
+	.owner		= THIS_MODULE,
+	.open		= uleds_open,
+	.release	= uleds_release,
+	.read		= uleds_read,
+	.write		= uleds_write,
+	.poll		= uleds_poll,
+	.llseek		= no_llseek,
+};
+
+static struct miscdevice uleds_misc = {
+	.fops		= &uleds_fops,
+	.minor		= MISC_DYNAMIC_MINOR,
+	.name		= ULEDS_NAME,
+};
+
+static int __init uleds_init(void)
+{
+	return misc_register(&uleds_misc);
+}
+module_init(uleds_init);
+
+static void __exit uleds_exit(void)
+{
+	misc_deregister(&uleds_misc);
+}
+module_exit(uleds_exit);
+
+MODULE_AUTHOR("David Lechner <david@lechnology.com>");
+MODULE_DESCRIPTION("Userspace driver for the LED subsystem");
+MODULE_LICENSE("GPL");

--- a/kmod-uleds/src/uleds.h
+++ b/kmod-uleds/src/uleds.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+/*
+ * Userspace driver support for the LED subsystem
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef _UAPI__ULEDS_H_
+#define _UAPI__ULEDS_H_
+
+#define LED_MAX_NAME_SIZE	64
+
+struct uleds_user_dev {
+	char name[LED_MAX_NAME_SIZE];
+	int max_brightness;
+};
+
+#endif /* _UAPI__ULEDS_H_ */

--- a/q14-uled-driver/Makefile
+++ b/q14-uled-driver/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2010-2012 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=q14-uled-driver
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=Brett Mastbergen <brettm@minim.com>
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/q14-uled-driver
+  SECTION:=minim
+  CATEGORY:=Minim
+  DEPENDS:=+kmod-uleds +coreutils-stty
+  TITLE:=q14 userspace led driver
+  MAINTAINER:=Brett Mastbergen <brettm@minim.com>
+  PKGARCH:=all
+endef
+
+define Package/q14-uled-driver/description
+  A userspace led driver for the Motorola Q14 utilizing
+  the uleds led class driver
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		CC="$(TARGET_CC)" \
+		CFLAGS="$(TARGET_CFLAGS) -Wall" \
+		LDFLAGS="$(TARGET_LDFLAGS)"
+endef
+
+define Package/q14-uled-driver/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/q14-uled-driver  $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/q14-uled-driver.init $(1)/etc/init.d/q14-uled-driver
+endef
+
+$(eval $(call BuildPackage,q14-uled-driver))

--- a/q14-uled-driver/files/q14-uled-driver.init
+++ b/q14-uled-driver/files/q14-uled-driver.init
@@ -1,0 +1,13 @@
+#!/bin/sh /etc/rc.common
+
+START=98
+
+USE_PROCD=1
+PROG=/usr/sbin/q14-uled-driver
+
+start_service() {
+	stty -F /dev/ttyMSM1 115200
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_close_instance
+}

--- a/q14-uled-driver/src/Makefile
+++ b/q14-uled-driver/src/Makefile
@@ -1,0 +1,7 @@
+all: q14-uled-driver
+
+q14-uled-driver: q14-uled-driver.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
+
+clean:
+	rm -f q14-uled-driver

--- a/q14-uled-driver/src/q14-uled-driver.c
+++ b/q14-uled-driver/src/q14-uled-driver.c
@@ -1,0 +1,165 @@
+/*
+ * The LEDs on the Motorola Q14 are controlled by a microcontroller
+ * attached to the main soc's 2nd uart controller (/dev/ttyMSM1).
+ *
+ * From the OEM documentation:
+ *
+ * 	Led is controlled by MCU
+ * 	MCU command is received from uart1
+ * 	The color is set by RGB value
+ * 	The command is combined with R+G+B+exam code
+ * 	exam code is the sum of R+G+B then use the lower 2 bytes
+ * 	examples:
+ * 	set it to yellow (0xff+0xff=0x1fe)
+ * 	echo -ne "\xff\xff\x0\xfe" > /dev/ttyMSM1
+ *
+ * In order to make the leds easier to manage, this userspace
+ * driver utilizes the kernel's uleds driver to implement standard
+ * LED class devices for red, green, and blue such that normal sysfs
+ * nodes can be used to control their brightness and triggers.
+ *
+ * The select statement waits for brightness change reports from the
+ * kernel, and then sets the current brightness values by writing
+ * them to the uart as described above.
+ *
+ */ 
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/select.h>
+
+#include "uleds.h"
+
+struct q14_uled {
+	struct uleds_user_dev uled;
+	int fd;
+	int current_brightness;
+};
+
+#define NUM_LEDS 3
+
+int main(int argc, char const *argv[])
+{
+	struct q14_uled leds[NUM_LEDS] = {
+			{
+			  .uled.name = "red",
+			  .uled.max_brightness = 255,
+			  .fd = -1,
+			  .current_brightness = 0
+			},
+			{
+			  .uled.name = "green",
+			  .uled.max_brightness = 255,
+			  .fd = -1,
+			  .current_brightness = 0
+			},
+			{
+			  .uled.name = "blue",
+			  .uled.max_brightness = 255,
+			  .fd = -1,
+			  .current_brightness = 0
+			},
+	};
+
+	struct timespec ts;
+	fd_set master;
+	int ret, i, ser_fd, max_fd = -1;
+	char buf[4];
+
+	FD_ZERO(&master);
+
+	/*
+	 * Register each color with the kernel's uleds driver.
+	 * Also add its file descriptor to the master set and
+	 * max_fd for use with select later.
+	 * 
+	 */
+	for(i = 0; i < NUM_LEDS; i++) {
+		leds[i].fd = open("/dev/uleds", O_RDWR);
+		if (leds[i].fd == -1) {
+			perror("Failed to open /dev/uleds");
+			goto exit;
+		}
+
+		ret = write(leds[i].fd, &leds[i].uled, sizeof(leds[i].uled));
+		if (ret == -1) {
+			perror("Failed to write to /dev/uleds");
+			goto exit;
+		}
+
+		FD_SET(leds[i].fd, &master);
+		
+		if(leds[i].fd > max_fd) {
+			max_fd = leds[i].fd;
+		}
+	}
+
+	/*
+	 * Wait in a select loop for brightness updates from
+	 * the kernel
+	 */
+	while(1) {
+		fd_set dup = master;
+		ret = select(max_fd+1, &dup, NULL, NULL, NULL);
+
+		if(ret == -1) {
+			perror("select() failed");
+			goto exit;
+		} else {
+			/*
+			 * For each file descriptor that the kernel has written to,
+			 * read the corresponding LED's current brightness value
+			 */
+			for(i = 0; i < NUM_LEDS; i++) {
+				if(FD_ISSET(leds[i].fd, &dup)) {
+					ret = read(leds[i].fd, &leds[i].current_brightness, sizeof(leds[i].current_brightness));
+					if(ret == -1) {
+						perror("read() failed");
+						goto exit;
+					}
+				}
+			}
+		}
+
+		/*
+		 * Create the buffer to send over the uart
+		 */
+		buf[3] = 0;
+		for(i = 0; i < NUM_LEDS; i++) {
+			buf[i] = leds[i].current_brightness;
+			buf[3] += buf[i];
+		}
+		buf[3] &= 0xff;
+
+
+		/*
+		 * Open the uart
+		 */
+		ser_fd = open("/dev/ttyMSM1", O_RDWR);
+		if (ser_fd == -1) {
+			perror("Failed to open /dev/ttyMSM1");
+			close(ser_fd);
+			goto exit;
+		}
+
+		/*
+		 * Write the command and close
+		 */
+		ret = write(ser_fd, buf, sizeof(buf));
+		close(ser_fd);
+		if (ret == -1) {
+			perror("Failed to write to /dev/ttyMSM1");
+			goto exit;
+		}
+	}
+
+exit:
+	for(i = 0; i < NUM_LEDS; i++) {
+		close(leds[i].fd);
+	}
+
+	return 0;
+}

--- a/q14-uled-driver/src/uleds.h
+++ b/q14-uled-driver/src/uleds.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+/*
+ * Userspace driver support for the LED subsystem
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#ifndef _UAPI__ULEDS_H_
+#define _UAPI__ULEDS_H_
+
+#define LED_MAX_NAME_SIZE	64
+
+struct uleds_user_dev {
+	char name[LED_MAX_NAME_SIZE];
+	int max_brightness;
+};
+
+#endif /* _UAPI__ULEDS_H_ */


### PR DESCRIPTION
First commit adds the kmod-uleds package, which is the uleds driver backported from the 4.10 kernel.
Second commit adds the q14-uled-driver, which is a userspace daemon that uses the uleds driver to implement standard LED class devices for the LEDs controlled via the device's uart.