### PR TITLE
minim-openwifi-scripts: Enable flow_offloading by default

### DIFF
--- a/minim-openwifi-scripts/Makefile
+++ b/minim-openwifi-scripts/Makefile
@@ -30,6 +30,7 @@ define Package/minim-openwifi-scripts/install
 	$(INSTALL_DATA) ./files/etc/uci-defaults/34_drop_wan_input $(1)/etc/uci-defaults
 	$(INSTALL_DATA) ./files/etc/uci-defaults/35_disable_maverick $(1)/etc/uci-defaults
 	$(INSTALL_DATA) ./files/etc/uci-defaults/36_disable_firstcontact_config $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/etc/uci-defaults/37_enable_flow_offloading $(1)/etc/uci-defaults
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/etc/init.d/update_leds $(1)/etc/init.d

--- a/minim-openwifi-scripts/files/etc/uci-defaults/37_enable_flow_offloading
+++ b/minim-openwifi-scripts/files/etc/uci-defaults/37_enable_flow_offloading
@@ -1,0 +1,3 @@
+# enable software flow offloading
+uci set firewall.@defaults[0].flow_offloading=1
+uci commit firewall


### PR DESCRIPTION
This is openwrt's software based flow offloading

SW-2393