### PR TITLE
web-landing: change update script to run every time we boot

### DIFF
--- a/web-landing/32_update_www_landing
+++ b/web-landing/32_update_www_landing
@@ -13,4 +13,4 @@ else
 fi
 VERSION=`unum -v`
 sed -i -e "s/__SERIAL__/${SERIAL}/" -e "s/__MAC__/${MAC}/" -e "s/__VERSION__/${VERSION}/" ${LANDING}
-exit 0
+exit 1


### PR DESCRIPTION
Script is renamed so it is not eclipsed by the scripts that have already run and been removed from the overlay.

SW-3383