### PR TITLE
performance-tuning: add affinity setting for r14 wifi interrupts

### DIFF
--- a/performance-tuning/99-smp-packet-steering-minim-defaults
+++ b/performance-tuning/99-smp-packet-steering-minim-defaults
@@ -16,6 +16,7 @@ case $(board_name) in
         motorola,r14)
               uci add_list minim.@smp_packet_steering[0].irqs="120:8"
               uci add_list minim.@smp_packet_steering[0].irqs="121:4"
+              uci add_list minim.@smp_packet_steering[0].irqs="123:2"
         ;;
 esac
 


### PR DESCRIPTION
SW-2899