### PR TITLE
crash-collector: Check for mfg_base_mac first

### DIFF
--- a/crash-collector/files/upload_crash_to_s3.sh
+++ b/crash-collector/files/upload_crash_to_s3.sh
@@ -5,10 +5,10 @@
 
 filename=$1
 upload=`basename $filename`
-mac=`fw_printenv -n ethaddr | tr '[A-F]' '[a-f]'`
+mac=`fw_printenv -n mfg_base_mac | tr '[A-F]' '[a-f]'`
 
 if [ -z $mac ] ; then
-	mac=`fw_printenv -n mfg_base_mac | tr '[A-F]' '[a-f]'`
+	mac=`fw_printenv -n ethaddr | tr '[A-F]' '[a-f]'`
 fi
 
 if [ -z $mac ] ; then


### PR DESCRIPTION
Some R14 have ethaddr and mfg_base_mac set, and we want it to use mfg_base_mac